### PR TITLE
docs: use required path for workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ pull requests or discussions by grouping them under the
 ## Examples
 
 The following workflow will perform the actions specified
-in the `.github/label-actions.yml` configuration file when an issue,
+in the `.github/workflows/label-actions.yml` configuration file when an issue,
 pull request or discussion is labeled or unlabeled.
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
## Changes:

- Use the correct path for the workflow file

## Context:

Quote from [GitHub Docs, about YAML syntax for workflows](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows):

> You must store workflow files in the `.github/workflows` directory of your repository.

## About Prettier formatting

I hope this is formatted correctly, I ran `npm ci` and then `npx prettier --write .`.
By the way Prettier fixed up two more files, which I did not include in this PR.

- `CHANGELOG.md`
- `dist/index.js`

If you want to ignore those files, put them in a `.prettierignore` file, read more here: https://prettier.io/docs/en/ignore.html#ignoring-files-prettierignore